### PR TITLE
Add toml support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectVersion>${project.version}</sonar.projectVersion>
+        <sonar.branch.name>add-toml-support</sonar.branch.name>
+        <sonar.brancg.target>master</sonar.brancg.target>
 
         <commons.io.version>2.5</commons.io.version>
         <junit.version>4.11</junit.version>

--- a/rust-frontend/rust-frontend.iml
+++ b/rust-frontend/rust-frontend.iml
@@ -6,6 +6,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/rust-frontend/src/main/java/org/sonar/rust/api/RustGrammar.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/api/RustGrammar.java
@@ -1,0 +1,15 @@
+package org.sonar.rust.api;
+
+import com.sonar.sslr.api.Grammar;
+import org.sonar.sslr.grammar.GrammarRuleKey;
+import org.sonar.sslr.grammar.LexerfulGrammarBuilder;
+
+
+public enum RustGrammar implements GrammarRuleKey {
+    ;
+
+    public static Grammar create() {
+        LexerfulGrammarBuilder b = LexerfulGrammarBuilder.create();
+        return b.buildWithMemoizationOfMatchesForAllRules();
+    }
+}

--- a/rust-frontend/src/main/java/org/sonar/rust/api/RustTokenType.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/api/RustTokenType.java
@@ -1,0 +1,26 @@
+package org.sonar.rust.api;
+
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.TokenType;
+
+public enum RustTokenType implements TokenType {
+    NUMBER,
+    STRING,
+    NEWLINE;
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public boolean hasToBeSkippedFromAst(AstNode node) {
+        return false;
+    }
+
+}

--- a/rust-frontend/src/main/java/org/sonar/rust/lexer/LexerState.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/lexer/LexerState.java
@@ -1,0 +1,4 @@
+package org.sonar.rust.lexer;
+
+public class LexerState {
+}

--- a/rust-frontend/src/main/java/org/sonar/rust/lexer/LexerState.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/lexer/LexerState.java
@@ -1,4 +1,0 @@
-package org.sonar.rust.lexer;
-
-public class LexerState {
-}

--- a/rust-frontend/src/main/java/org/sonar/rust/lexer/NewLineChannel.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/lexer/NewLineChannel.java
@@ -1,0 +1,82 @@
+package org.sonar.rust.lexer;
+
+import com.sonar.sslr.api.Token;
+import com.sonar.sslr.impl.Lexer;
+import org.sonar.rust.api.RustTokenType;
+import org.sonar.sslr.channel.Channel;
+import org.sonar.sslr.channel.CodeReader;
+
+
+
+public class NewLineChannel extends Channel<Lexer> {
+
+
+
+    public NewLineChannel() {
+
+    }
+
+    @Override
+    public boolean consume(CodeReader code, Lexer output) {
+        char ch = (char) code.peek();
+
+        if ((ch == '\\') && isNewLine(code.charAt(1))) {
+            // Explicit line joining
+            code.pop();
+            consumeEOL(code);
+            return true;
+        }
+
+        if (isNewLine(ch)) {
+            processNewLine(code, output);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean processNewLine(CodeReader code, Lexer output) {
+
+        if (output.getTokens().isEmpty() || (output.getTokens().get(output.getTokens().size() - 1).getType().equals(RustTokenType.NEWLINE))) {
+            // Blank line
+            consumeEOL(code);
+            return true;
+        }
+
+        // NEWLINE token
+        output.addToken(Token.builder()
+                .setLine(code.getLinePosition())
+                .setColumn(code.getColumnPosition())
+                .setURI(output.getURI())
+                .setType(RustTokenType.NEWLINE)
+                .setValueAndOriginalValue("\n")
+                .setGeneratedCode(true)
+                .build());
+        consumeEOL(code);
+        return false;
+    }
+
+
+
+    private void joinLines(CodeReader code) {
+        while (Character.isWhitespace(code.peek())) {
+            code.pop();
+        }
+    }
+
+    private static void consumeEOL(CodeReader code) {
+        if ((code.charAt(0) == '\r') && (code.charAt(1) == '\n')) {
+            // \r\n
+            code.pop();
+            code.pop();
+        } else {
+            // \r or \n
+            code.pop();
+        }
+    }
+
+    private static boolean isNewLine(char ch) {
+        return (ch == '\n') || (ch == '\r');
+    }
+
+}

--- a/rust-frontend/src/main/java/org/sonar/rust/lexer/RustLexer.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/lexer/RustLexer.java
@@ -7,8 +7,16 @@ public class RustLexer {
 
     }
 
-    public static Lexer create(LexerState lexerState) {
+    public static Lexer create() {
         Lexer.Builder builder = Lexer.builder().withFailIfNoChannelToConsumeOneCharacter(true);
+        addCommonChannels(builder);
         return builder.build();
     }
+
+    private static void addCommonChannels(Lexer.Builder builder) {
+        builder
+                .withChannel(new NewLineChannel());
+    }
+
+
 }

--- a/rust-frontend/src/main/java/org/sonar/rust/lexer/RustLexer.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/lexer/RustLexer.java
@@ -1,0 +1,14 @@
+package org.sonar.rust.lexer;
+
+import com.sonar.sslr.impl.Lexer;
+
+public class RustLexer {
+    private RustLexer(){
+
+    }
+
+    public static Lexer create(LexerState lexerState) {
+        Lexer.Builder builder = Lexer.builder().withFailIfNoChannelToConsumeOneCharacter(true);
+        return builder.build();
+    }
+}

--- a/rust-frontend/src/main/java/org/sonar/rust/parser/RustParser.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/parser/RustParser.java
@@ -1,0 +1,7 @@
+package org.sonar.rust.parser;
+
+public class RustParser {
+    public static RustParser create() {
+        return new RustParser();
+    }
+}

--- a/rust-frontend/src/main/java/org/sonar/rust/parser/RustParser.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/parser/RustParser.java
@@ -1,27 +1,36 @@
 package org.sonar.rust.parser;
 
+import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.api.Token;
 import com.sonar.sslr.impl.Lexer;
 import com.sonar.sslr.impl.Parser;
 import org.sonar.rust.api.RustGrammar;
-import org.sonar.rust.lexer.LexerState;
 import org.sonar.rust.lexer.RustLexer;
 
-public class RustParser extends Parser<Grammar> {
-    private final LexerState lexerState;
+import java.util.List;
+
+public final class RustParser extends Parser<Grammar> {
     private final Lexer lexer;
 
-
-    public RustParser() {
+    private RustParser() {
         super(RustGrammar.create());
         super.setRootRule(super.getGrammar().getRootRule());
-        this.lexerState = new LexerState();
-        this.lexer = RustLexer.create(lexerState);
+
+        this.lexer = RustLexer.create();
     }
-
-
 
     public static RustParser create() {
         return new RustParser();
+    }
+
+    @Override
+    public AstNode parse(String source) {
+        lexer.lex(source);
+        return super.parse(tokens());
+    }
+
+    private List<Token> tokens() {
+        return  lexer.getTokens();
     }
 }

--- a/rust-frontend/src/main/java/org/sonar/rust/parser/RustParser.java
+++ b/rust-frontend/src/main/java/org/sonar/rust/parser/RustParser.java
@@ -1,6 +1,26 @@
 package org.sonar.rust.parser;
 
-public class RustParser {
+import com.sonar.sslr.api.Grammar;
+import com.sonar.sslr.impl.Lexer;
+import com.sonar.sslr.impl.Parser;
+import org.sonar.rust.api.RustGrammar;
+import org.sonar.rust.lexer.LexerState;
+import org.sonar.rust.lexer.RustLexer;
+
+public class RustParser extends Parser<Grammar> {
+    private final LexerState lexerState;
+    private final Lexer lexer;
+
+
+    public RustParser() {
+        super(RustGrammar.create());
+        super.setRootRule(super.getGrammar().getRootRule());
+        this.lexerState = new LexerState();
+        this.lexer = RustLexer.create(lexerState);
+    }
+
+
+
     public static RustParser create() {
         return new RustParser();
     }

--- a/rust-frontend/src/test/java/org/sonar/rust/parser/RustParserTest.java
+++ b/rust-frontend/src/test/java/org/sonar/rust/parser/RustParserTest.java
@@ -1,0 +1,30 @@
+package org.sonar.rust.parser;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collection;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class RustParserTest {
+
+    private final RustParser parser = RustParser.create();
+
+    @Test
+    public void test() throws Exception {
+        Collection<File> files = listFiles();
+        for (File file : files) {
+            String fileContent = new String(Files.readAllBytes(file.toPath()), UTF_8);
+            parser.parse(fileContent);
+        }
+    }
+
+    private static Collection<File> listFiles() {
+        File dir = new File("src/test/resources/parser/");
+        return FileUtils.listFiles(dir, new String[]{"rs"}, true);
+    }
+
+}

--- a/rust-frontend/src/test/java/org/sonar/rust/parser/RustParserTest.java
+++ b/rust-frontend/src/test/java/org/sonar/rust/parser/RustParserTest.java
@@ -1,5 +1,6 @@
 package org.sonar.rust.parser;
 
+import com.sonar.sslr.api.AstNode;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
@@ -8,17 +9,20 @@ import java.nio.file.Files;
 import java.util.Collection;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RustParserTest {
 
     private final RustParser parser = RustParser.create();
 
     @Test
-    public void test() throws Exception {
+    public void testParse() throws Exception {
         Collection<File> files = listFiles();
+        AstNode node;
         for (File file : files) {
             String fileContent = new String(Files.readAllBytes(file.toPath()), UTF_8);
-            parser.parse(fileContent);
+            node =parser.parse(fileContent);
+            assertThat(node).isNotNull();
         }
     }
 

--- a/sonar-rust-plugin/src/main/java/org/elegoff/plugins/rust/RustScanner.java
+++ b/sonar-rust-plugin/src/main/java/org/elegoff/plugins/rust/RustScanner.java
@@ -1,0 +1,76 @@
+package org.elegoff.plugins.rust;
+
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.issue.NoSonarFilter;
+import org.sonar.api.measures.FileLinesContextFactory;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonarsource.analyzer.commons.ProgressReport;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.sonar.rust.parser.RustParser;
+
+public class RustScanner {
+    private static final Logger LOG = Loggers.get(RustScanner.class);
+    private static final String FAIL_FAST_PROPERTY_NAME = "sonar.internal.analysis.failFast";
+    private final SensorContext context;
+    private final RustParser parser;
+    private final Map<InputFile, String> packageNames = new HashMap<>();
+    private final RustChecks checks;
+    private final FileLinesContextFactory fileLinesContextFactory;
+    private final NoSonarFilter noSonarFilter;
+
+
+
+    public RustScanner(SensorContext context, RustChecks checks, FileLinesContextFactory fileLinesContextFactory, NoSonarFilter noSonarFilter, List<InputFile> mainFiles) {
+        this.context = context;
+        this.checks = checks;
+        this.fileLinesContextFactory = fileLinesContextFactory;
+        this.noSonarFilter = noSonarFilter;
+        this.parser = RustParser.create();
+
+    }
+
+    public void execute(List<InputFile> files, SensorContext context) {
+        ProgressReport progressReport = new ProgressReport(this.name() + " progress", TimeUnit.SECONDS.toMillis(10));
+        LOG.info("Starting " + this.name());
+        List<String> filenames = files.stream().map(InputFile::toString).collect(Collectors.toList());
+        progressReport.start(filenames);
+        for (InputFile file : files) {
+            if (context.isCancelled()) {
+                progressReport.cancel();
+                return;
+            }
+            try {
+                this.scanFile(file);
+            } catch (Exception e) {
+                this.processException(e, file);
+                if (context.config().getBoolean(FAIL_FAST_PROPERTY_NAME).orElse(false)) {
+                    throw new IllegalStateException("Exception when analyzing " + file, e);
+                }
+            } finally {
+                progressReport.nextFile();
+            }
+        }
+
+        progressReport.stop();
+    }
+
+    private String name() {
+        return "rules execution";
+    }
+
+    public void scanFile(InputFile file) throws IOException{
+        LOG.debug("Scanning file: " + file.toString());
+    };
+
+    public  void processException(Exception e, InputFile file){
+        LOG.warn("Unable to analyze file: " + file.toString(), e);
+    };
+}

--- a/sonar-rust-plugin/src/main/java/org/elegoff/plugins/rust/settings/RustLanguageSettings.java
+++ b/sonar-rust-plugin/src/main/java/org/elegoff/plugins/rust/settings/RustLanguageSettings.java
@@ -34,7 +34,7 @@ import static java.util.Arrays.asList;
 public class RustLanguageSettings {
     public static final String FILE_SUFFIXES_KEY = "sonar.rust.file.suffixes";
     public static final String FILTER_UTF8_LB_KEY = "sonar.rust.filter.utf8_lb";
-    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".rs";
+    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".rs,.toml";
 
 
     /**

--- a/sonar-rust-plugin/src/main/resources/org/elegoff/l10n/rust/rules/clippy/clippylints.json
+++ b/sonar-rust-plugin/src/main/resources/org/elegoff/l10n/rust/rules/clippy/clippylints.json
@@ -1336,57 +1336,52 @@
   },
   {
     "key": "clippy::same_functions_in_if_condition",
-    "name": "TODO",
+    "name": "Checks for consecutive ifs with the same function call.",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#same_functions_in_if_condition"
   },
   {
     "key": "clippy::search_is_some",
-    "name": "TODO",
+    "name": "Checks for an iterator search (such as find(), position(), or rposition()) followed by a call to is_some().",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some"
   },
   {
     "key": "clippy::serde_api_misuse",
-    "name": "TODO",
+    "name": "Checks for mis-uses of the serde API.",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#serde_api_misuse"
   },
   {
     "key": "clippy::shadow_reuse",
-    "name": "TODO",
+    "name": "Checks for bindings that shadow other bindings already in scope, while reusing the original value.",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#shadow_reuse"
   },
   {
     "key": "clippy::shadow_same",
-    "name": "TODO",
+    "name": "Checks for bindings that shadow other bindings already in scope, while just changing reference level or mutability.",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#shadow_same"
   },
   {
     "key": "clippy::shadow_unrelated",
-    "name": "TODO",
+    "name": "Checks for bindings that shadow other bindings already in scope",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#shadow_unrelated"
   },
   {
     "key": "clippy::short_circuit_statement",
-    "name": "TODO",
+    "name": "Checks for the use of short circuit boolean conditions as a statement.",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#short_circuit_statement"
   },
   {
-    "key": "clippy::should_assert_eq",
-    "name": "TODO",
-    "url": "https://rust-lang.github.io/rust-clippy/master/index.html#should_assert_eq"
-  },
-  {
     "key": "clippy::should_implement_trait",
-    "name": "TODO",
+    "name": "Checks for methods that should live in a trait implementation of a std trait",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait"
   },
   {
     "key": "clippy::similar_names",
-    "name": "TODO",
+    "name": "Checks for names that are very similar and thus confusing.",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#similar_names"
   },
   {
     "key": "clippy::single_char_pattern",
-    "name": "TODO",
+    "name": "Checks for string methods that receive a single-character str as an argument",
     "url": "https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern"
   },
   {

--- a/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/Utils.java
+++ b/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/Utils.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 
@@ -86,6 +87,14 @@ public class Utils {
                 .setLanguage("Rust")
                 .setType(InputFile.Type.MAIN).build();
         return inputFile;
+    }
+
+    public static String fileContent(File file, Charset charset) {
+        try {
+            return new String(java.nio.file.Files.readAllBytes(file.toPath()), charset);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read " + file, e);
+        }
     }
 
 

--- a/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/clippy/ClippyRulesDefinitionTest.java
+++ b/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/clippy/ClippyRulesDefinitionTest.java
@@ -39,7 +39,7 @@ public class ClippyRulesDefinitionTest {
         assertThat(repository.name()).isEqualTo("Clippy");
         assertThat(repository.language()).isEqualTo("rust");
         assertThat(repository.isExternal()).isEqualTo(true);
-        assertThat(repository.rules().size()).isEqualTo(379);
+        assertThat(repository.rules().size()).isEqualTo(378);
 
         RulesDefinition.Rule rule = repository.rule("clippy::absurd_extreme_comparisons");
         assertThat(rule).isNotNull();

--- a/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/clippy/ClippySensorTest.java
+++ b/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/clippy/ClippySensorTest.java
@@ -123,7 +123,7 @@ public class ClippySensorTest{
                 .startsWith("No issues information will be saved as the report file '")
                 .contains("invalid-path.txt' can't be read.");
     }
-/*
+
     @Test
     public void issuesWhenClippyFileHasErrors() throws IOException {
         List<ExternalIssue> externalIssues = executeSensorImporting(7, 9, "wrongpaths.txt");
@@ -142,7 +142,7 @@ public class ClippySensorTest{
                 .isEqualTo("Failed to resolve 1 file path(s) in Clippy report. No issues imported related to file(s): clippy/wrong.rs");
         assertThat(logTester.logs(LoggerLevel.DEBUG)).containsExactly("Missing information for ruleKey:'clippy::absurd_extreme_comparisons', filePath:'clippy/wrong.rs', message:'null'");
     }
-*/
+
     @Test
     public void noIssuesWithEmptyClippyReport() throws IOException {
         List<ExternalIssue> externalIssues = executeSensorImporting(7, 9, "empty-report.txt");

--- a/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/language/RustLanguageTest.java
+++ b/sonar-rust-plugin/src/test/java/org/elegoff/plugins/rust/language/RustLanguageTest.java
@@ -33,15 +33,15 @@ public class RustLanguageTest {
         RustLanguage language = new RustLanguage(new ConfigurationBridge(new MapSettings()));
         assertThat(language.getKey()).isEqualTo("rust");
         assertThat(language.getName()).isEqualTo("Rust");
-        assertThat(language.getFileSuffixes()).hasSize(1).contains(".rs");
+        assertThat(language.getFileSuffixes()).hasSize(2).contains(".rs");
     }
 
     @Test
     public void custom_file_suffixes() {
         MapSettings settings = new MapSettings();
-        settings.setProperty(RustLanguageSettings.FILE_SUFFIXES_KEY, "rs");
+        settings.setProperty(RustLanguageSettings.FILE_SUFFIXES_KEY, "foo,bar");
 
         RustLanguage language = new RustLanguage(new ConfigurationBridge(settings));
-        assertThat(language.getFileSuffixes()).hasSize(1).contains("rs");
+        assertThat(language.getFileSuffixes()).hasSize(2).contains("foo");
     }
 }


### PR DESCRIPTION
Some of the clippy rules apply to the Cargo.toml definition
Therefore `.toml` should be a valid extension on top of `.rs`