### PR TITLE
Resolve files relative to clippy report

### DIFF
--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippyJsonReportReader.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippyJsonReportReader.java
@@ -22,6 +22,7 @@ package org.elegoff.plugins.communityrust.clippy;
 
 import javax.annotation.Nullable;
 import java.io.*;
+import java.nio.file.Paths;
 import java.util.stream.Stream;
 import java.util.function.Consumer;
 
@@ -34,6 +35,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ClippyJsonReportReader {
     private final JSONParser jsonParser = new JSONParser();
+    private final String projectDir;
     private final Consumer<ClippyIssue> consumer;
     private static final String RESULTS = "results";
     private static final String BEGINJSON = "{\"" + RESULTS + "\": [";
@@ -60,12 +62,13 @@ public class ClippyJsonReportReader {
         String severity;
     }
 
-    private ClippyJsonReportReader(Consumer<ClippyIssue> consumer) {
+    private ClippyJsonReportReader(String projectDir, Consumer<ClippyIssue> consumer) {
+        this.projectDir = projectDir;
         this.consumer = consumer;
     }
 
-    static void read(InputStream in, Consumer<ClippyIssue> consumer) throws IOException, ParseException {
-        new ClippyJsonReportReader(consumer).read(in);
+    static void read(InputStream in, String projectDir, Consumer<ClippyIssue> consumer) throws IOException, ParseException {
+        new ClippyJsonReportReader(projectDir, consumer).read(in);
     }
 
     private void read(InputStream in) throws IOException, ParseException {
@@ -93,7 +96,7 @@ public class ClippyJsonReportReader {
         if ((spans == null) || spans.isEmpty()) return; //Exit silently when JSON is not compliant
 
         JSONObject span = (JSONObject) spans.get(0);
-        clippyIssue.filePath = (String) span.get("file_name");
+        clippyIssue.filePath = Paths.get(this.projectDir, (String) span.get("file_name")).toString();
         clippyIssue.message = (String) message.get(MESSAGE);
         JSONArray children = (JSONArray) message.get("children");
 

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippySensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippySensor.java
@@ -65,7 +65,8 @@ public class ClippySensor implements Sensor {
 
         try {
             InputStream in = ClippyJsonReportReader.toJSON(rawReport);
-            ClippyJsonReportReader.read(in, clippyIssue -> saveIssue(context, clippyIssue, unresolvedInputFiles));
+            String projectDir = rawReport.getParent();
+            ClippyJsonReportReader.read(in, projectDir, clippyIssue -> saveIssue(context, clippyIssue, unresolvedInputFiles));
         } catch (IOException | ParseException e) {
             LOG.error("No issues information will be saved as the report file '{}' can't be read. " +
                     e.getClass().getSimpleName() + ": " + e.getMessage(), rawReport, e);


### PR DESCRIPTION
Hey there,

I'd like to contribute a small fix for an issue I've had with the sonar-rust plugin

## The issue

I was trying to use the sonar-rust plugin within a mono-repo with the following structure:
```
frontend/
backend/
  src/
    main.rs
  Cargo.toml
  clippy.report
sonar-project.properties
```

Although the rust files were detected by sonar, they could not be resolved by the clippy report parser, which gave me the following warning:
```log
WARN: Failed to resolve 9 file path(s) in Clippy report. No issues imported related to file(s): src/main.rs
```

## The fix

I've added a `projectDir` to the `ClippyJsonReportReader`, which will resolve every file listed inside the clippy report relative to the report file itself.

