### PR TITLE
JUnit report

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -77,5 +77,5 @@ This Community Rust plugin doesn't run your tests or generate tests reports for 
 
 Currently, only `junit report` formats are supported :
 
-Insert a parameter `sonar.test.reportPath` into you `sonar-project.properties` file. As an example, one of such tool 
+Insert a parameter `sonar.rust.test.reportPath` into you `sonar-project.properties` file. As an example, one of such tool 
 for Rust than converts `cargo test` report to `junit report` is [cargo2junit](https://crates.io/crates/cargo2junit).

--- a/DOC.md
+++ b/DOC.md
@@ -69,4 +69,13 @@ e.g
 But [other coverage tools](https://vladfilippov.com/blog/rust-code-coverage-tools/) might work as well
 
 
+## Adding test measures
 
+Optionally SonarQube can also display tests measures.
+
+This Community Rust plugin doesn't run your tests or generate tests reports for you. That has to be done before analysis and provided in the form of reports.
+
+Currently, only `junit report` formats are supported :
+
+Insert a parameter `sonar.test.reportPath` into you `sonar-project.properties` file. As an example, one of such tool 
+for Rust than converts `cargo test` report to `junit report` is [cargo2junit](https://crates.io/crates/cargo2junit).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ It leverages [Clippy lints](https://rust-lang.github.io/rust-clippy/master/) to 
 * Import it into SonarQube
    
 set analysis parameter `community.rust.clippy.reportPaths=<CLIPPY REPORT FILE>`
+
+* Optionally import tests measures (`junit` report)
+
+use `sonar.test.reportPath`
+
 * Optionally import coverage measures 
 
 use either 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ set analysis parameter `community.rust.clippy.reportPaths=<CLIPPY REPORT FILE>`
 
 * Optionally import tests measures (`junit` report)
 
-use `sonar.test.reportPath`
+use `sonar.rust.test.reportPath`
 
 * Optionally import coverage measures 
 

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/CommunityRustPlugin.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/CommunityRustPlugin.java
@@ -23,6 +23,7 @@ package org.elegoff.plugins.communityrust;
 import org.elegoff.plugins.communityrust.coverage.cobertura.CoberturaSensor;
 import org.elegoff.plugins.communityrust.coverage.lcov.LCOVSensor;
 import org.elegoff.plugins.communityrust.rules.RustRulesDefinition;
+import org.elegoff.plugins.communityrust.xunit.XUnitSensor;
 import org.sonar.api.Plugin;
 import org.sonar.api.config.PropertyDefinition;
 import org.elegoff.plugins.communityrust.clippy.ClippySensor;
@@ -90,6 +91,18 @@ public class CommunityRustPlugin implements Plugin {
 
 
         );
+
+
+        context.addExtensions(
+                PropertyDefinition.builder(XUnitSensor.REPORT_PATH_KEY)
+                        .name("Path to xunit report(s)")
+                        .description("Path to the report of test execution, relative to project's root. Ant patterns are accepted. The reports have to conform to the junitreport XML format.")
+                        .category("Rust")
+                        .subCategory("Test and Coverage")
+                        .onQualifiers(Qualifiers.PROJECT)
+                        .defaultValue(XUnitSensor.DEFAULT_REPORT_PATH)
+                        .build(),
+                XUnitSensor.class);
 
 
     }

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/StaxParser.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/StaxParser.java
@@ -1,6 +1,25 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
-import com.ctc.wstx.stax.WstxInputFactory;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.staxmate.SMInputFactory;
 import org.codehaus.staxmate.in.SMHierarchicCursor;

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/StaxParser.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/StaxParser.java
@@ -1,0 +1,69 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.staxmate.SMInputFactory;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLResolver;
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+public class StaxParser {
+
+  private SMInputFactory inf;
+
+  private XmlStreamHandler streamHandler;
+
+  public StaxParser(XmlStreamHandler streamHandler) {
+    this.streamHandler = streamHandler;
+    XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+
+    inf = new SMInputFactory(xmlFactory);
+  }
+
+  public void parse(File xmlFile) throws XMLStreamException {
+    try (FileInputStream input = new FileInputStream(xmlFile)) {
+      parse(input);
+    } catch (IOException e) {
+      throw new XMLStreamException(e);
+    }
+  }
+
+  public void parse(InputStream xmlInput) throws XMLStreamException {
+    SMHierarchicCursor rootCursor = inf.rootElementCursor(xmlInput);
+    try {
+      streamHandler.stream(rootCursor);
+    } finally {
+      rootCursor.getStreamReader().closeCompletely();
+    }
+  }
+
+  private static class UndeclaredEntitiesXMLResolver implements XMLResolver {
+
+    @Override
+    public Object resolveEntity(String arg0, String arg1, String fileName, String undeclaredEntity) throws XMLStreamException {
+      String undeclared = undeclaredEntity;
+      // avoid problems with XML docs containing undeclared entities.. return the entity under its raw form if not a Unicode expression
+      if (StringUtils.startsWithIgnoreCase(undeclaredEntity, "u") && undeclaredEntity.length() == 5) {
+        int unicodeCharHexValue = Integer.parseInt(undeclaredEntity.substring(1), 16);
+        if (Character.isDefined(unicodeCharHexValue)) {
+          undeclared = new String(new char[] {(char) unicodeCharHexValue});
+        }
+      }
+      return undeclared;
+    }
+  }
+
+  /**
+   * Simple interface for handling XML stream to parse.
+   */
+  @FunctionalInterface
+  public interface XmlStreamHandler {
+    void stream(SMHierarchicCursor rootCursor) throws XMLStreamException;
+  }
+
+}

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCase.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCase.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 import javax.annotation.Nullable;

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCase.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCase.java
@@ -1,0 +1,68 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a unit test case. Has a couple of data items like name, status, time etc. associated. Reports testcase details in
+ * sonar-conform XML
+ */
+public class TestCase {
+    private final String name;
+    private final TestCaseStatus status;
+    private final String stackTrace;
+    private final String errorMessage;
+    private final int time;
+    private final String file;
+    private final String testClassname;
+
+    /**
+     * Constructs a testcase instance out of following parameters
+     * @param name  The name of this testcase
+     * @param status The execution status of the testcase
+     * @param stackTrace The stack trace occurred while executing of this testcase; pass "" if the testcase passed/skipped.
+     * @param errorMessage The error message associated with this testcase of the execution was erroneous; pass "" if not.
+     * @param time The execution time in milliseconds
+     * @param file The optional file to which this test case applies.
+     * @param testClassname The classname of the test.
+     */
+    public TestCase(String name, TestCaseStatus status, String stackTrace, String errorMessage, int time, @Nullable String file, @Nullable  String testClassname) {
+        this.name = name;
+        this.status = status;
+        this.stackTrace = stackTrace;
+        this.errorMessage = errorMessage;
+        this.time = time;
+        this.file = file;
+        this.testClassname = testClassname;
+    }
+    /**
+     * Returns true if this testcase is an error, false otherwise
+     */
+    public boolean isError(){
+        return TestCaseStatus.ERROR.equals(status);
+    }
+    /**
+     * Returns true if this testcase is a failure, false otherwise
+     */
+    public boolean isFailure(){
+        return TestCaseStatus.FAILURE.equals(status);
+    }
+
+    /**
+     * Returns true if this testcase has been skipped, failure, false otherwise
+     */
+    public boolean isSkipped() {
+        return TestCaseStatus.SKIPPED.equals(status);
+    }
+
+    public int getTime() {
+        return time;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public String getTestClassname() {
+        return testClassname;
+    }
+}

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCaseStatus.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCaseStatus.java
@@ -1,0 +1,23 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+public enum TestCaseStatus {
+    OK("ok"),
+    ERROR("error"),
+    FAILURE("failure"),
+    SKIPPED("skipped");
+    private final String text;
+
+    TestCaseStatus(String name) {
+        this.text = name;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+
+    public static TestCaseStatus getFromIgnoreCaseString(String value) {
+        return TestCaseStatus.valueOf(value.toUpperCase());
+    }
+}
+

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCaseStatus.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestCaseStatus.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 public enum TestCaseStatus {

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestResult.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestResult.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 public class TestResult {

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestResult.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestResult.java
@@ -1,0 +1,46 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+public class TestResult {
+    private int errors = 0;
+    private int skipped = 0;
+    private int tests = 0;
+    private int time = 0;
+    private int failures = 0;
+
+
+    public int getErrors() {
+        return errors;
+    }
+
+    public int getSkipped() {
+        return skipped;
+    }
+
+    public int getTests() {
+        return tests;
+    }
+
+    public int getExecutedTests() {
+        return tests - skipped;
+    }
+
+    public int getTime() {
+        return time;
+    }
+
+    public int getFailures() {
+        return failures;
+    }
+
+    public void addTestCase(TestCase tc) {
+        if (tc.isSkipped()) {
+            skipped++;
+        } else if (tc.isFailure()) {
+            failures++;
+        } else if (tc.isError()) {
+            errors++;
+        }
+        tests++;
+        time += tc.getTime();
+    }
+}

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuite.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuite.java
@@ -1,0 +1,50 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a unit test suite. Contains testcases, maintains some statistics. Reports testcase details in sonar-conform XML
+ */
+public class TestSuite {
+
+    private String key;
+    private List<TestCase> testCases;
+
+    /**
+     * Creates a testsuite instance uniquely identified by the given key
+     *
+     * @param key
+     *          The key to construct a testsuite for
+     */
+    public TestSuite(String key) {
+        this.key = key;
+        this.testCases = new ArrayList<>();
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void addTestCase(TestCase tc) {
+        testCases.add(tc);
+    }
+
+    public List<TestCase> getTestCases() {
+        return testCases;
+    }
+
+//    /**
+//     * Returns execution details as sonar-conform XML
+//     */
+//    public String getDetails() {
+//        StringBuilder details = new StringBuilder();
+//        details.append("<tests-details>");
+//        for (TestCase tc : testCases) {
+//            details.append(tc.getDetails());
+//        }
+//        details.append("</tests-details>");
+//        return details.toString();
+//    }
+
+}

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuite.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuite.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 import java.util.ArrayList;
@@ -33,18 +53,4 @@ public class TestSuite {
     public List<TestCase> getTestCases() {
         return testCases;
     }
-
-//    /**
-//     * Returns execution details as sonar-conform XML
-//     */
-//    public String getDetails() {
-//        StringBuilder details = new StringBuilder();
-//        details.append("<tests-details>");
-//        for (TestCase tc : testCases) {
-//            details.append(tc.getDetails());
-//        }
-//        details.append("</tests-details>");
-//        return details.toString();
-//    }
-
 }

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuiteParser.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuiteParser.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 import org.codehaus.staxmate.in.ElementFilter;

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuiteParser.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/TestSuiteParser.java
@@ -1,0 +1,93 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+import org.codehaus.staxmate.in.ElementFilter;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+import org.codehaus.staxmate.in.SMInputCursor;
+import org.sonar.api.utils.ParsingUtils;
+
+import javax.xml.stream.XMLStreamException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+public class TestSuiteParser implements StaxParser.XmlStreamHandler {
+    private List<TestSuite> testSuites = new ArrayList<>();
+
+    @Override
+    public void stream(SMHierarchicCursor rootCursor) throws XMLStreamException {
+        SMInputCursor testSuiteCursor = rootCursor.constructDescendantCursor(new ElementFilter("testsuite"));
+        while (testSuiteCursor.getNext() != null) {
+            String testSuiteClassName = getExpectedAttribute(testSuiteCursor, "name");
+            TestSuite testSuite = new TestSuite(testSuiteClassName);
+            testSuites.add(testSuite);
+            SMInputCursor testCaseCursor = testSuiteCursor.childElementCursor("testcase");
+
+            while (testCaseCursor.getNext() != null) {
+                testSuite.addTestCase(parseTestCaseTag(testCaseCursor));
+            }
+        }
+    }
+
+    public Collection<TestSuite> getParsedReports() {
+        return testSuites;
+    }
+
+    private static TestCase parseTestCaseTag(SMInputCursor testCaseCursor) throws XMLStreamException {
+        String name = parseTestCaseName(testCaseCursor);
+        Double time = parseTime(testCaseCursor);
+        TestCaseStatus status = TestCaseStatus.OK;
+        String stack = "";
+        String msg = "";
+
+        String file = testCaseCursor.getAttrValue("file");
+        String testClassName = testCaseCursor.getAttrValue("classname");
+
+        SMInputCursor childCursor = testCaseCursor.childElementCursor();
+        if (childCursor.getNext() != null) {
+            String elementName = childCursor.getLocalName();
+            TestCaseStatus testCaseStatus = TestCaseStatus.getFromIgnoreCaseString(elementName);
+            if (TestCaseStatus.SKIPPED.equals(testCaseStatus)) {
+                status = TestCaseStatus.SKIPPED;
+            } else if (TestCaseStatus.FAILURE.equals(testCaseStatus)) {
+                status = TestCaseStatus.FAILURE;
+                msg = getExpectedAttribute(childCursor, "message");
+                stack = childCursor.collectDescendantText();
+            } else if (TestCaseStatus.ERROR.equals(testCaseStatus)) {
+                status = TestCaseStatus.ERROR;
+                msg = getExpectedAttribute(childCursor, "message");
+                stack = childCursor.collectDescendantText();
+            }
+        }
+        return new TestCase(name, status, stack, msg, time.intValue(), file, testClassName);
+    }
+
+    private static double parseTime(SMInputCursor testCaseCursor) throws XMLStreamException {
+        double time;
+        try {
+            double tmp = ParsingUtils.parseNumber(getExpectedAttribute(testCaseCursor, "time"), Locale.ENGLISH);
+            time = ParsingUtils.scaleValue(tmp * 1000, 3);
+        } catch (ParseException e) {
+            throw new XMLStreamException(e);
+        }
+        return time;
+    }
+
+    private static String getExpectedAttribute(SMInputCursor testCaseCursor, String attributeName) throws XMLStreamException {
+        String attrValue = testCaseCursor.getAttrValue(attributeName);
+        if (attrValue == null) {
+            throw new IllegalStateException(String.format("Missing attribute '%s' at line %d", attributeName, testCaseCursor.getStreamLocation().getLineNumber()));
+        }
+        return attrValue;
+    }
+
+    private static String parseTestCaseName(SMInputCursor testCaseCursor) throws XMLStreamException {
+        String name = getExpectedAttribute(testCaseCursor, "name");
+        String classname = testCaseCursor.getAttrValue("CLASSNAME");
+        if (classname != null) {
+            name = classname + "/" + name;
+        }
+        return name;
+    }
+}

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
@@ -23,11 +23,6 @@ public class XUnitSensor implements Sensor {
     public static final String REPORT_PATH_KEY = "sonar.test.reportPath";
     public static final String DEFAULT_REPORT_PATH = "rust-test.xml";
     private static final Logger LOG = Loggers.get(XUnitSensor.class);
-    protected final Configuration conf;
-
-    public XUnitSensor(Configuration conf) {
-        this.conf = conf;
-    }
 
     @Override
     public void describe(SensorDescriptor descriptor) {
@@ -40,8 +35,10 @@ public class XUnitSensor implements Sensor {
 
     @Override
     public void execute(SensorContext context) {
+        Configuration conf = context.config();
         String reportPathPropertyKey = REPORT_PATH_KEY;
         String reportPath = conf.get(reportPathPropertyKey).orElse(DEFAULT_REPORT_PATH);
+
         try {
             List<File> reports = getReports(conf, context.fileSystem().baseDir().getPath(), reportPathPropertyKey, reportPath);
             processReports(context, reports);

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 
 public class XUnitSensor implements Sensor {
-    public static final String REPORT_PATH_KEY = "sonar.test.reportPath";
+    public static final String REPORT_PATH_KEY = "sonar.rust.test.reportPath";
     public static final String DEFAULT_REPORT_PATH = "rust-test.xml";
     private static final Logger LOG = Loggers.get(XUnitSensor.class);
 

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/xunit/XUnitSensor.java
@@ -1,0 +1,112 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+
+import org.elegoff.plugins.communityrust.language.RustLanguage;
+import org.sonar.api.batch.fs.InputComponent;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonarsource.analyzer.commons.FileProvider;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.util.List;
+
+
+public class XUnitSensor implements Sensor {
+    public static final String REPORT_PATH_KEY = "sonar.test.reportPath";
+    public static final String DEFAULT_REPORT_PATH = "rust-test.xml";
+    private static final Logger LOG = Loggers.get(XUnitSensor.class);
+    protected final Configuration conf;
+
+    public XUnitSensor(Configuration conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public void describe(SensorDescriptor descriptor) {
+        descriptor
+                .name("XUnit Sensor for Rust")
+                .onlyOnLanguage(RustLanguage.KEY)
+                .onlyOnFileType(InputFile.Type.MAIN);
+        ;
+    }
+
+    @Override
+    public void execute(SensorContext context) {
+        String reportPathPropertyKey = REPORT_PATH_KEY;
+        String reportPath = conf.get(reportPathPropertyKey).orElse(DEFAULT_REPORT_PATH);
+        try {
+            List<File> reports = getReports(conf, context.fileSystem().baseDir().getPath(), reportPathPropertyKey, reportPath);
+            processReports(context, reports);
+        } catch (Exception e) {
+            LOG.warn("Cannot read report '{}', the following exception occurred: {}", reportPath, e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void processReports(SensorContext context, List<File> reports) throws XMLStreamException {
+        TestSuiteParser parserHandler = new TestSuiteParser();
+        StaxParser parser = new StaxParser(parserHandler);
+        for (File report : reports) {
+            parser.parse(report);
+        }
+        TestResult total = new TestResult();
+        parserHandler.getParsedReports().forEach(testSuite -> testSuite.getTestCases().forEach(total::addTestCase));
+
+        if (total.getTests() > 0) {
+            InputComponent module = context.project();
+            saveMeasure(context, module, CoreMetrics.TESTS, total.getExecutedTests());
+            saveMeasure(context, module, CoreMetrics.SKIPPED_TESTS, total.getSkipped());
+            saveMeasure(context, module, CoreMetrics.TEST_ERRORS, total.getErrors());
+            saveMeasure(context, module, CoreMetrics.TEST_FAILURES, total.getFailures());
+            saveMeasure(context, module, CoreMetrics.TEST_EXECUTION_TIME, total.getTime());
+        }
+
+    }
+
+    public static List<File> getReports(Configuration conf, String baseDirPath, String reportPathPropertyKey, String reportPath) {
+        LOG.debug("Using pattern '{}' to find reports", reportPath);
+
+        FileProvider provider = new FileProvider(new File(baseDirPath), reportPath);
+        List<File> matchingFiles = provider.getMatchingFiles();
+
+        if (matchingFiles.isEmpty()) {
+            if (conf.hasKey(reportPathPropertyKey)) {
+                // try absolute path
+                File file = new File(reportPath);
+                if (!file.exists()) {
+                    LOG.warn("No report was found for {} using pattern {}", reportPathPropertyKey, reportPath);
+                } else {
+                    matchingFiles.add(file);
+                }
+            } else {
+                LOG.debug("No report was found for {} using default pattern {}", reportPathPropertyKey, reportPath);
+            }
+        }
+        return matchingFiles;
+    }
+
+    private static void saveMeasure(SensorContext context, InputComponent component, Metric<Integer> metric, int value) {
+        context.<Integer>newMeasure()
+                .on(component)
+                .forMetric(metric)
+                .withValue(value)
+                .save();
+    }
+
+    private static void saveMeasure(SensorContext context, InputComponent component, Metric<Long> metric, long value) {
+        context.<Long>newMeasure()
+                .on(component)
+                .forMetric(metric)
+                .withValue(value)
+                .save();
+    }
+
+}

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/CommunityRustPluginTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/CommunityRustPluginTest.java
@@ -39,9 +39,9 @@ public class CommunityRustPluginTest extends TestCase {
     public void testGetExtensions() {
         Version v79 = Version.create(7, 9);
         SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(v79, SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
-        assertThat(extensions(runtime)).hasSize(13);
+        assertThat(extensions(runtime)).hasSize(15);
         assertThat(extensions(runtime)).contains(ClippyRulesDefinition.class);
-        assertThat(extensions(SonarRuntimeImpl.forSonarLint(v79))).hasSize(13);
+        assertThat(extensions(SonarRuntimeImpl.forSonarLint(v79))).hasSize(15);
     }
 
     private static List extensions(SonarRuntime runtime) {

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestResultTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestResultTest.java
@@ -1,3 +1,24 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 package org.elegoff.plugins.communityrust.xunit;
 
 import org.junit.Before;
@@ -9,86 +30,86 @@ import static org.mockito.Mockito.when;
 
 public class TestResultTest {
 
-  TestResult testResult;
+    TestResult testResult;
 
-  @Before
-  public void setUp() {
-    testResult = new TestResult();
-  }
+    @Before
+    public void setUp() {
+        testResult = new TestResult();
+    }
 
-  @Test
-  public void newBornSuiteShouldHaveVirginStatistics() {
-    assertThat(testResult.getTests()).isEqualTo(0);
-    assertThat(testResult.getExecutedTests()).isEqualTo(0);
-    assertThat(testResult.getErrors()).isEqualTo(0);
-    assertThat(testResult.getFailures()).isEqualTo(0);
-    assertThat(testResult.getSkipped()).isEqualTo(0);
-    assertThat(testResult.getTime()).isEqualTo(0);
-  }
+    @Test
+    public void newBornSuiteShouldHaveVirginStatistics() {
+        assertThat(testResult.getTests()).isEqualTo(0);
+        assertThat(testResult.getExecutedTests()).isEqualTo(0);
+        assertThat(testResult.getErrors()).isEqualTo(0);
+        assertThat(testResult.getFailures()).isEqualTo(0);
+        assertThat(testResult.getSkipped()).isEqualTo(0);
+        assertThat(testResult.getTime()).isEqualTo(0);
+    }
 
-  @Test
-  public void addingTestCaseShouldIncrementStatistics() {
-    int testBefore = testResult.getTests();
-    int timeBefore = testResult.getTime();
+    @Test
+    public void addingTestCaseShouldIncrementStatistics() {
+        int testBefore = testResult.getTests();
+        int timeBefore = testResult.getTime();
 
-    final int EXEC_TIME = 10;
-    testResult.addTestCase(createTestCase(EXEC_TIME, "ok"));
+        final int EXEC_TIME = 10;
+        testResult.addTestCase(createTestCase(EXEC_TIME, "ok"));
 
-    assertThat(testResult.getTests()).isEqualTo(testBefore + 1);
-    assertThat(testResult.getTime()).isEqualTo(timeBefore + EXEC_TIME);
-  }
+        assertThat(testResult.getTests()).isEqualTo(testBefore + 1);
+        assertThat(testResult.getTime()).isEqualTo(timeBefore + EXEC_TIME);
+    }
 
-  @Test
-  public void executedTestsValue() {
-    testResult.addTestCase(createTestCase(1, "ok"));
-    testResult.addTestCase(createTestCase(2, "skipped"));
-    testResult.addTestCase(createTestCase(3, "ok"));
-    testResult.addTestCase(createTestCase(4, "error"));
-    testResult.addTestCase(createTestCase(5, "skipped"));
+    @Test
+    public void executedTestsValue() {
+        testResult.addTestCase(createTestCase(1, "ok"));
+        testResult.addTestCase(createTestCase(2, "skipped"));
+        testResult.addTestCase(createTestCase(3, "ok"));
+        testResult.addTestCase(createTestCase(4, "error"));
+        testResult.addTestCase(createTestCase(5, "skipped"));
 
-    assertThat(testResult.getTests()).isEqualTo(5);
-    assertThat(testResult.getExecutedTests()).isEqualTo(3);
-    assertThat(testResult.getErrors()).isEqualTo(1);
-    assertThat(testResult.getFailures()).isEqualTo(0);
-    assertThat(testResult.getSkipped()).isEqualTo(2);
-    assertThat(testResult.getTime()).isEqualTo(15);
-  }
+        assertThat(testResult.getTests()).isEqualTo(5);
+        assertThat(testResult.getExecutedTests()).isEqualTo(3);
+        assertThat(testResult.getErrors()).isEqualTo(1);
+        assertThat(testResult.getFailures()).isEqualTo(0);
+        assertThat(testResult.getSkipped()).isEqualTo(2);
+        assertThat(testResult.getTime()).isEqualTo(15);
+    }
 
-  private static TestCase createTestCase(int time, String status) {
-    return new TestCase("name", TestCaseStatus.getFromIgnoreCaseString(status), "stack", "msg", time,"file", "testClassname");
-  }
+    private static TestCase createTestCase(int time, String status) {
+        return new TestCase("name", TestCaseStatus.getFromIgnoreCaseString(status), "stack", "msg", time, "file", "testClassname");
+    }
 
-  @Test
-  public void addingAnErroneousTestCaseShouldIncrementErrorStatistic() {
-    int errorsBefore = testResult.getErrors();
-    TestCase error = mock(TestCase.class);
-    when(error.isError()).thenReturn(true);
+    @Test
+    public void addingAnErroneousTestCaseShouldIncrementErrorStatistic() {
+        int errorsBefore = testResult.getErrors();
+        TestCase error = mock(TestCase.class);
+        when(error.isError()).thenReturn(true);
 
-    testResult.addTestCase(error);
+        testResult.addTestCase(error);
 
-    assertThat(testResult.getErrors()).isEqualTo(errorsBefore + 1);
-  }
+        assertThat(testResult.getErrors()).isEqualTo(errorsBefore + 1);
+    }
 
-  @Test
-  public void addingAFailedestCaseShouldIncrementFailedStatistic() {
-    int failedBefore = testResult.getFailures();
-    TestCase failedTC = mock(TestCase.class);
-    when(failedTC.isFailure()).thenReturn(true);
+    @Test
+    public void addingAFailedestCaseShouldIncrementFailedStatistic() {
+        int failedBefore = testResult.getFailures();
+        TestCase failedTC = mock(TestCase.class);
+        when(failedTC.isFailure()).thenReturn(true);
 
-    testResult.addTestCase(failedTC);
+        testResult.addTestCase(failedTC);
 
-    assertThat(testResult.getFailures()).isEqualTo(failedBefore + 1);
-  }
+        assertThat(testResult.getFailures()).isEqualTo(failedBefore + 1);
+    }
 
-  @Test
-  public void addingASkippedTestCaseShouldIncrementSkippedStatistic() {
-    int skippedBefore = testResult.getSkipped();
-    TestCase skippedTC = mock(TestCase.class);
-    when(skippedTC.isSkipped()).thenReturn(true);
+    @Test
+    public void addingASkippedTestCaseShouldIncrementSkippedStatistic() {
+        int skippedBefore = testResult.getSkipped();
+        TestCase skippedTC = mock(TestCase.class);
+        when(skippedTC.isSkipped()).thenReturn(true);
 
-    testResult.addTestCase(skippedTC);
+        testResult.addTestCase(skippedTC);
 
-    assertThat(testResult.getSkipped()).isEqualTo(skippedBefore + 1);
-  }
+        assertThat(testResult.getSkipped()).isEqualTo(skippedBefore + 1);
+    }
 
 }

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestResultTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestResultTest.java
@@ -1,0 +1,94 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestResultTest {
+
+  TestResult testResult;
+
+  @Before
+  public void setUp() {
+    testResult = new TestResult();
+  }
+
+  @Test
+  public void newBornSuiteShouldHaveVirginStatistics() {
+    assertThat(testResult.getTests()).isEqualTo(0);
+    assertThat(testResult.getExecutedTests()).isEqualTo(0);
+    assertThat(testResult.getErrors()).isEqualTo(0);
+    assertThat(testResult.getFailures()).isEqualTo(0);
+    assertThat(testResult.getSkipped()).isEqualTo(0);
+    assertThat(testResult.getTime()).isEqualTo(0);
+  }
+
+  @Test
+  public void addingTestCaseShouldIncrementStatistics() {
+    int testBefore = testResult.getTests();
+    int timeBefore = testResult.getTime();
+
+    final int EXEC_TIME = 10;
+    testResult.addTestCase(createTestCase(EXEC_TIME, "ok"));
+
+    assertThat(testResult.getTests()).isEqualTo(testBefore + 1);
+    assertThat(testResult.getTime()).isEqualTo(timeBefore + EXEC_TIME);
+  }
+
+  @Test
+  public void executedTestsValue() {
+    testResult.addTestCase(createTestCase(1, "ok"));
+    testResult.addTestCase(createTestCase(2, "skipped"));
+    testResult.addTestCase(createTestCase(3, "ok"));
+    testResult.addTestCase(createTestCase(4, "error"));
+    testResult.addTestCase(createTestCase(5, "skipped"));
+
+    assertThat(testResult.getTests()).isEqualTo(5);
+    assertThat(testResult.getExecutedTests()).isEqualTo(3);
+    assertThat(testResult.getErrors()).isEqualTo(1);
+    assertThat(testResult.getFailures()).isEqualTo(0);
+    assertThat(testResult.getSkipped()).isEqualTo(2);
+    assertThat(testResult.getTime()).isEqualTo(15);
+  }
+
+  private static TestCase createTestCase(int time, String status) {
+    return new TestCase("name", TestCaseStatus.getFromIgnoreCaseString(status), "stack", "msg", time,"file", "testClassname");
+  }
+
+  @Test
+  public void addingAnErroneousTestCaseShouldIncrementErrorStatistic() {
+    int errorsBefore = testResult.getErrors();
+    TestCase error = mock(TestCase.class);
+    when(error.isError()).thenReturn(true);
+
+    testResult.addTestCase(error);
+
+    assertThat(testResult.getErrors()).isEqualTo(errorsBefore + 1);
+  }
+
+  @Test
+  public void addingAFailedestCaseShouldIncrementFailedStatistic() {
+    int failedBefore = testResult.getFailures();
+    TestCase failedTC = mock(TestCase.class);
+    when(failedTC.isFailure()).thenReturn(true);
+
+    testResult.addTestCase(failedTC);
+
+    assertThat(testResult.getFailures()).isEqualTo(failedBefore + 1);
+  }
+
+  @Test
+  public void addingASkippedTestCaseShouldIncrementSkippedStatistic() {
+    int skippedBefore = testResult.getSkipped();
+    TestCase skippedTC = mock(TestCase.class);
+    when(skippedTC.isSkipped()).thenReturn(true);
+
+    testResult.addTestCase(skippedTC);
+
+    assertThat(testResult.getSkipped()).isEqualTo(skippedBefore + 1);
+  }
+
+}

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestSuiteTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestSuiteTest.java
@@ -1,0 +1,20 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class TestSuiteTest {
+
+    @Test
+    public void test() {
+        TestSuite suite = new TestSuite("key");
+        assertThat(suite.getKey()).isEqualTo("key");
+        assertThat(suite.getTestCases()).isEmpty();
+
+        TestCase testCase = new TestCase("name", TestCaseStatus.OK, "stack", "msg", 1, "file", "testClassname");
+        suite.addTestCase(testCase);
+        assertThat(suite.getTestCases()).containsExactly(testCase);
+    }
+
+}

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestSuiteTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/TestSuiteTest.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 import org.junit.Test;

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/XUnitSensorTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/XUnitSensorTest.java
@@ -62,6 +62,13 @@ public class XUnitSensorTest {
         assertThat(moduleMeasure(CoreMetrics.TEST_FAILURES)).isEqualTo(1);
     }
 
+    @Test
+    public void shouldReportNothingWhenNoReportFound() {
+        settings.setProperty(XUnitSensor.REPORT_PATH_KEY, "notexistingpath");
+        unitSensor.execute(context);
+        assertThat(context.measures(context.module().key())).isEmpty();
+    }
+
     private Integer moduleMeasure(Metric<Integer> metric) {
         return measure(context.module(), metric);
     }

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/XUnitSensorTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/XUnitSensorTest.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.xunit;
 
 

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/XUnitSensorTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/xunit/XUnitSensorTest.java
@@ -1,0 +1,74 @@
+package org.elegoff.plugins.communityrust.xunit;
+
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.sonar.api.batch.fs.InputComponent;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.utils.log.LogTester;
+
+import java.io.File;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class XUnitSensorTest {
+    private XUnitSensor unitSensor;
+    private SensorContextTester context;
+    private MapSettings settings;
+
+    private File moduleBaseDir = new File("src/test/resources/org/elegoff/plugins/communityrust/xunit").getAbsoluteFile();
+
+    @Rule
+    public LogTester logTester = new LogTester();
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    @Before
+    public void init() {
+
+        unitSensor = new XUnitSensor();
+        settings = new MapSettings();
+        settings.setProperty(XUnitSensor.REPORT_PATH_KEY, "basic.xml");
+        context = SensorContextTester.create(moduleBaseDir);
+        context.setSettings(settings);
+    }
+
+    @Test
+    public void test_basic_report() {
+        unitSensor.execute(context);
+        assertThat(moduleMeasure(CoreMetrics.TESTS)).isEqualTo(1);
+        assertThat(moduleMeasure(CoreMetrics.SKIPPED_TESTS)).isEqualTo(0);
+        assertThat(moduleMeasure(CoreMetrics.TEST_ERRORS)).isEqualTo(0);
+        assertThat(moduleMeasure(CoreMetrics.TEST_FAILURES)).isEqualTo(0);
+    }
+
+    @Test
+    public void test_report_with_failure() {
+
+        settings.setProperty(XUnitSensor.REPORT_PATH_KEY, "report_with_failure.xml");
+        context = SensorContextTester.create(moduleBaseDir);
+        context.setSettings(settings);
+
+        unitSensor.execute(context);
+        assertThat(moduleMeasure(CoreMetrics.TESTS)).isEqualTo(13);
+        assertThat(moduleMeasure(CoreMetrics.SKIPPED_TESTS)).isEqualTo(0);
+        assertThat(moduleMeasure(CoreMetrics.TEST_ERRORS)).isEqualTo(0);
+        assertThat(moduleMeasure(CoreMetrics.TEST_FAILURES)).isEqualTo(1);
+    }
+
+    private Integer moduleMeasure(Metric<Integer> metric) {
+        return measure(context.module(), metric);
+    }
+
+    private Integer measure(InputComponent component, Metric<Integer> metric) {
+        return context.measure(component.key(), metric).value();
+    }
+
+
+}

--- a/community-rust-plugin/src/test/resources/org/elegoff/plugins/communityrust/xunit/basic.xml
+++ b/community-rust-plugin/src/test/resources/org/elegoff/plugins/communityrust/xunit/basic.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2022-01-11T10:31:34.916885967+00:00" time="0" />
+    <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="1" errors="0" failures="0" hostname="localhost" timestamp="2022-01-11T10:31:34.916885967+00:00" time="0.000027991">
+        <testcase name="test_get_study_by_id" classname="tests" time="0.000027991" />
+    </testsuite>
+</testsuites>

--- a/community-rust-plugin/src/test/resources/org/elegoff/plugins/communityrust/xunit/report_with_failure.xml
+++ b/community-rust-plugin/src/test/resources/org/elegoff/plugins/communityrust/xunit/report_with_failure.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="11" errors="0" failures="0" hostname="localhost" timestamp="2022-01-11T13:42:00.527327642+00:00" time="0.000089607">
+        <testcase name="test_cop" classname="types::instance_type::tests" time="0.000001716" />
+        <testcase name="test_csp" classname="types::instance_type::tests" time="0.00000157" />
+        <testcase name="test_err" classname="types::instance_type::tests" time="0.000008028" />
+        <testcase name="test_entities_merge_successive_values" classname="types::integer_domain::tests" time="0.000007322" />
+        <testcase name="test_entities_sort" classname="types::integer_domain::tests" time="0.000007333" />
+        <testcase name="test_entity_new_value" classname="types::integer_domain::tests" time="0.00000058" />
+        <testcase name="test_entity_new_interval_wrong_domain" classname="types::integer_domain::tests" time="0.000042525" />
+        <testcase name="test_entity_order" classname="types::integer_domain::tests" time="0.000001023" />
+        <testcase name="test_entities_merge_successive_intervals" classname="types::integer_domain::tests" time="0.000004575" />
+        <testcase name="test_entity_new_interval" classname="types::integer_domain::tests" time="0.000000693" />
+        <testcase name="test_entities_merge_common_parts" classname="types::integer_domain::tests" time="0.000014242" />
+    </testsuite>
+    <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="2" errors="0" failures="1" hostname="localhost" timestamp="2022-01-11T13:42:00.527327642+00:00" time="0.000899536">
+        <testcase name="test_extension_unary" classname="tests" time="0.00042398">
+            <failure type="cargo test" message="failed tests::test_extension_unary"><![CDATA[thread 'tests::test_extension_unary' panicked at 'assertion failed: `(left == right)`
+  left: `5`,
+ right: `4`', tests/test_constraints_extension.rs:139:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+]]></failure>
+        </testcase>
+        <testcase name="test_extension" classname="tests" time="0.000475556" />
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
This pull request adds the ability to interpret reports in "JUnit" format to display the number of unit tests on the Sonarqube page like the following image : 
 
![Capture d’écran de 2022-01-12 10-16-53](https://user-images.githubusercontent.com/6603358/149102101-f2e76d20-edbc-440e-a893-c153f56271f6.png)

This PR creates global statistics from the JUnit file. 

- Number of tests
- Number of failure tests
- Number of skipped tests
- Number of error tests