### PR TITLE
Fix handling clippy paths - issue #65

### DIFF
--- a/community-rust-plugin/pom.xml
+++ b/community-rust-plugin/pom.xml
@@ -132,8 +132,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>10</source>
-                    <target>10</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippyJsonReportReader.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippyJsonReportReader.java
@@ -28,8 +28,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.Paths;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippyJsonReportReader.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippyJsonReportReader.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -46,16 +47,15 @@ public class ClippyJsonReportReader {
   private static final String VISIT_MSG = "for further information visit";
   private static final String MESSAGE = "message";
   private final JSONParser jsonParser = new JSONParser();
-  private final String projectDir;
+
   private final Consumer<ClippyIssue> consumer;
 
-  private ClippyJsonReportReader(String projectDir, Consumer<ClippyIssue> consumer) {
-    this.projectDir = projectDir;
+  private ClippyJsonReportReader(Consumer<ClippyIssue> consumer) {
     this.consumer = consumer;
   }
 
-  static void read(InputStream in, String projectDir, Consumer<ClippyIssue> consumer) throws IOException, ParseException {
-    new ClippyJsonReportReader(projectDir, consumer).read(in);
+  static void read(InputStream in,  Consumer<ClippyIssue> consumer) throws IOException, ParseException {
+    new ClippyJsonReportReader(consumer).read(in);
   }
 
   private static String suggestedMessage(JSONObject obj) {
@@ -113,6 +113,7 @@ public class ClippyJsonReportReader {
     }
   }
 
+
   private void onResult(JSONObject result) {
 
     var clippyIssue = new ClippyIssue();
@@ -132,7 +133,7 @@ public class ClippyJsonReportReader {
       return; // Exit silently when JSON is not compliant
 
     JSONObject span = (JSONObject) spans.get(0);
-    clippyIssue.filePath = Paths.get(this.projectDir, (String) span.get("file_name")).toString();
+    clippyIssue.filePath = (String) span.get("file_name");
     clippyIssue.message = (String) message.get(MESSAGE);
     JSONArray children = (JSONArray) message.get("children");
 

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippySensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippySensor.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.elegoff.plugins.communityrust.language.RustLanguage;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.Sensor;
@@ -40,6 +41,8 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonarsource.analyzer.commons.ExternalReportProvider;
 import org.sonarsource.analyzer.commons.internal.json.simple.parser.ParseException;
 
+import javax.annotation.CheckForNull;
+
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
 public class ClippySensor implements Sensor {
@@ -51,13 +54,22 @@ public class ClippySensor implements Sensor {
   private static final Long DEFAULT_CONSTANT_DEBT_MINUTES = 5L;
   private static final int MAX_LOGGED_FILE_NAMES = 20;
 
+  private static FileAdjustor fileAdjustor;
+
+  @CheckForNull
+  private static InputFile inputFile(SensorContext context, String filePath) {
+    String relativePath = fileAdjustor.relativePath(filePath);
+    return context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(relativePath));
+  }
+
   private static void saveIssue(SensorContext context, ClippyJsonReportReader.ClippyIssue clippyIssue, Set<String> unresolvedInputFiles) {
     if (isEmpty(clippyIssue.ruleKey) || isEmpty(clippyIssue.filePath) || isEmpty(clippyIssue.message)) {
       LOG.debug("Missing information for ruleKey:'{}', filePath:'{}', message:'{}'", clippyIssue.ruleKey, clippyIssue.filePath, clippyIssue.message);
       return;
     }
 
-    var inputFile = context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(clippyIssue.filePath));
+    InputFile inputFile = inputFile(context, clippyIssue.filePath);
+
     if (inputFile == null) {
       unresolvedInputFiles.add(clippyIssue.filePath);
       return;
@@ -97,6 +109,7 @@ public class ClippySensor implements Sensor {
   @Override
   public void execute(SensorContext context) {
     Set<String> unresolvedInputFiles = new HashSet<>();
+    fileAdjustor = FileAdjustor.create(context);
     List<File> reportFiles = ExternalReportProvider.getReportFiles(context, reportPathKey());
     reportFiles.forEach(report -> importReport(report, context, unresolvedInputFiles));
     logUnresolvedInputFiles(unresolvedInputFiles);
@@ -107,8 +120,7 @@ public class ClippySensor implements Sensor {
 
     try {
       InputStream in = ClippyJsonReportReader.toJSON(rawReport);
-      String projectDir = rawReport.getParent();
-      ClippyJsonReportReader.read(in, projectDir, clippyIssue -> saveIssue(context, clippyIssue, unresolvedInputFiles));
+      ClippyJsonReportReader.read(in, clippyIssue -> saveIssue(context, clippyIssue, unresolvedInputFiles));
     } catch (IOException | ParseException e) {
       LOG.error("No issues information will be saved as the report file '{}' can't be read. " +
         e.getClass().getSimpleName() + ": " + e.getMessage(), rawReport, e);

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippySensor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/ClippySensor.java
@@ -54,15 +54,15 @@ public class ClippySensor implements Sensor {
   private static final Long DEFAULT_CONSTANT_DEBT_MINUTES = 5L;
   private static final int MAX_LOGGED_FILE_NAMES = 20;
 
-  private static FileAdjustor fileAdjustor;
+  private FileAdjustor fileAdjustor;
 
   @CheckForNull
-  private static InputFile inputFile(SensorContext context, String filePath) {
+  private  InputFile inputFile(SensorContext context, String filePath) {
     String relativePath = fileAdjustor.relativePath(filePath);
     return context.fileSystem().inputFile(context.fileSystem().predicates().hasPath(relativePath));
   }
 
-  private static void saveIssue(SensorContext context, ClippyJsonReportReader.ClippyIssue clippyIssue, Set<String> unresolvedInputFiles) {
+  private  void saveIssue(SensorContext context, ClippyJsonReportReader.ClippyIssue clippyIssue, Set<String> unresolvedInputFiles) {
     if (isEmpty(clippyIssue.ruleKey) || isEmpty(clippyIssue.filePath) || isEmpty(clippyIssue.message)) {
       LOG.debug("Missing information for ruleKey:'{}', filePath:'{}', message:'{}'", clippyIssue.ruleKey, clippyIssue.filePath, clippyIssue.message);
       return;

--- a/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/FileAdjustor.java
+++ b/community-rust-plugin/src/main/java/org/elegoff/plugins/communityrust/clippy/FileAdjustor.java
@@ -1,0 +1,108 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021-2023 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.elegoff.plugins.communityrust.clippy;
+
+
+import java.io.File;
+import java.nio.file.Path;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.sensor.SensorContext;
+
+  /**
+   * Adjust file paths from clippy reports into a path relative to the project.
+   * The context in which the report was created and the analyzer context may possibly be different.
+   */
+  public class FileAdjustor {
+
+    private final FileSystem fileSystem;
+
+    private int relativePathOffset = 0;
+
+    private FileAdjustor(FileSystem fileSystem) {
+      this.fileSystem = fileSystem;
+    }
+
+    public static FileAdjustor create(SensorContext context) {
+      return new FileAdjustor(context.fileSystem());
+    }
+
+    public String relativePath(String fileName) {
+
+      if (isKnown(fileName)) {
+        return fileName;
+      }
+
+      String normalizedPath = chooseSeparator(fileName);
+      if (normalizedPath == null) {
+        return fileName;
+      }
+
+      Path path = Path.of(normalizedPath);
+      int pathNameCount = path.getNameCount();
+
+      if (relativePathOffset > 0) {
+        if (path.getNameCount() > relativePathOffset) {
+          path = path.subpath(relativePathOffset, pathNameCount);
+          if (isKnown(path)) {
+            return path.toString();
+          }
+        }
+        return fileName;
+      }
+
+
+      for (int i = 1; i < pathNameCount; i++) {
+        Path subpath = path.subpath(i, pathNameCount);
+        if (isKnown(subpath)) {
+          relativePathOffset = i;
+          return subpath.toString();
+        }
+      }
+
+      return fileName;
+    }
+
+
+    private static String chooseSeparator(String path) {
+      return isWindows() ? windowsSeparators(path) : unixSeparators(path);
+    }
+
+    private static boolean isWindows() {
+      return File.separatorChar == '\\';
+    }
+
+    private static String unixSeparators(String path) {
+      return path.indexOf(92) != -1 ? path.replace('\\', '/') : path;
+    }
+
+    private static String windowsSeparators(String path) {
+      return path.indexOf(47) != -1 ? path.replace('/', '\\') : path;
+    }
+
+
+    private boolean isKnown(Path path) {
+      return isKnown(path.toString());
+    }
+
+    private boolean isKnown(String path) {
+      return fileSystem.hasFiles(fileSystem.predicates().hasPath(path));
+    }
+}

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/clippy/FileAdjustorTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/clippy/FileAdjustorTest.java
@@ -1,3 +1,23 @@
+/**
+ * Community Rust Plugin
+ * Copyright (C) 2021-2023 Eric Le Goff
+ * mailto:community-rust AT pm DOT me
+ * http://github.com/elegoff/sonar-rust
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.elegoff.plugins.communityrust.clippy;
 
 

--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/clippy/FileAdjustorTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/clippy/FileAdjustorTest.java
@@ -1,0 +1,108 @@
+package org.elegoff.plugins.communityrust.clippy;
+
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileAdjustorTest {
+
+  private static final Path PROJECT_DIR = Paths.get("src", "test", "resources", "FileAdjustor");
+  private static final String MODULE_KEY = "FileAdjustor";
+
+  private FileAdjustor fileAdjustor;
+
+  private SensorContextTester context;
+
+  @Before
+  public void setup() {
+    context =  SensorContextTester.create(PROJECT_DIR);
+    addInputFiles("main.rs", "subfolder/main.rs");
+    fileAdjustor = FileAdjustor.create(context);
+  }
+
+  @Test
+  public void should_return_relative_path_when_all_files_are_known() {
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "main.rs"))).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "subfolder", "main.rs"))).isEqualTo(path("subfolder", "main.rs"));
+  }
+
+  @Test
+  public void should_return_relative_path_when_first_file_is_in_subfolder() {
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "subfolder", "main.rs"))).isEqualTo(path("subfolder", "main.rs"));
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "main.rs"))).isEqualTo("main.rs");
+  }
+
+
+  @Test
+  public void should_not_return_relative_when_files_are_unknown() {
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "unknown.rs"))).isEqualTo(path("foo", "bar", "FileAdjustor", "unknown.rs"));
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "subfolder", "unknown.rs"))).isEqualTo(path("foo", "bar", "FileAdjustor", "subfolder", "unknown.rs"));
+  }
+
+  @Test
+  public void should_return_relative_when_first_file_is_unknown() {
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "unknown.rs"))).isEqualTo(path("foo", "bar", "FileAdjustor", "unknown.rs"));
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "subfolder", "main.rs"))).isEqualTo(path("subfolder", "main.rs"));
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "main.rs"))).isEqualTo("main.rs");
+  }
+
+  @Test
+  public void should_return_relative_path_when_already_relative() {
+    assertThat(fileAdjustor.relativePath("main.rs")).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath(path("subfolder", "main.rs"))).isEqualTo(path("subfolder", "main.rs"));
+  }
+
+  @Test
+  public void test() {
+    assertThat(fileAdjustor.relativePath(path("unknown", "main.rs"))).isEqualTo(path("main.rs"));
+    assertThat(fileAdjustor.relativePath("main.rs")).isEqualTo("main.rs");
+  }
+
+  @Test
+  public void should_return_relative_path_for_second_file_when_unknown() {
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileHandler", "main.rs"))).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileHandler", "subfolder", "unknown.rs"))).isEqualTo(path("foo", "bar", "FileHandler", "subfolder", "unknown.rs"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_unix_path() {
+    assertThat(fileAdjustor.relativePath("/foo/bar/FileAdjustor/main.rs")).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath("/foo/bar/FileAdjustor/subfolder/main.rs")).isEqualTo(path("subfolder", "main.rs"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_fqn_windows_path() {
+    assertThat(fileAdjustor.relativePath("C:\\foo\\bar\\FileAdjustor\\main.rs")).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath("C:\\foo\\bar\\FileAdjustor\\subfolder\\main.rs")).isEqualTo(path("subfolder", "main.rs"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_relative_windows_path() {
+    assertThat(fileAdjustor.relativePath("main.rs")).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath("subfolder\\main.rs")).isEqualTo("subfolder\\main.rs");
+  }
+
+  @Test
+  public void should_return_handle_shorter_path() {
+    assertThat(fileAdjustor.relativePath(path("foo", "bar", "FileAdjustor", "main.rs"))).isEqualTo("main.rs");
+    assertThat(fileAdjustor.relativePath(path("bar",  "main.rs"))).isEqualTo(path("bar","main.rs"));
+  }
+
+
+  private void addInputFiles(String... paths) {
+    Arrays.stream(paths).forEach(path -> context.fileSystem().add(TestInputFileBuilder.create(MODULE_KEY, path).build()));
+  }
+
+  private static String path(String first, String... more) {
+    return Path.of(first, more).toString();
+  }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.version>9.7.1.62043</sonar.version>
         <sonar.plugin.api.version>9.11.0.290</sonar.plugin.api.version>
+      <sonar.branch.name>fix-handling-clippy-paths</sonar.branch.name>
+<sonar.branch.target>master</sonar.branch.target>
 
       <!-- Advertise minimal required JRE version -->
       <jre.min.version>11</jre.min.version>


### PR DESCRIPTION
Fixing - Clippy reports fail to load if stored in a subdirectory or different file tree