### PR TITLE
Update sonar, fix cobertura tests

### DIFF
--- a/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/coverage/cobertura/StaxParserTest.java
+++ b/community-rust-plugin/src/test/java/org/elegoff/plugins/communityrust/coverage/cobertura/StaxParserTest.java
@@ -47,9 +47,9 @@ class StaxParserTest {
 
   @Test
   void test_grammars() throws XMLStreamException {
-    assertDoesNotThrow(() -> test_grammar_parsable("org/elegoff/plugins/communityRust/cobertura/dtd-test.xml"));
-    assertDoesNotThrow(() -> test_grammar_parsable("org/elegoff/plugins/communityRust/cobertura/xsd-test.xml"));
-    assertDoesNotThrow(() -> test_grammar_parsable("org/elegoff/plugins/communityRust/cobertura/xsd-test-with-entity.xml"));
+    assertDoesNotThrow(() -> test_grammar_parsable("org/elegoff/plugins/communityrust/cobertura/dtd-test.xml"));
+    assertDoesNotThrow(() -> test_grammar_parsable("org/elegoff/plugins/communityrust/cobertura/xsd-test.xml"));
+    assertDoesNotThrow(() -> test_grammar_parsable("org/elegoff/plugins/communityrust/cobertura/xsd-test-with-entity.xml"));
   }
 
   private static StaxParser.XmlStreamHandler getTestHandler() {

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.version>9.9.1.69595</sonar.version>
-        <sonar.plugin.api.version>10.4.0.2064</sonar.plugin.api.version>
+        <sonar.plugin.api.version>10.5.0.2090</sonar.plugin.api.version>
 
 
       <!-- Advertise minimal required JRE version -->
@@ -87,7 +87,7 @@
         <commons.io.version>2.15.1</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
         <junit.version>5.9.3</junit.version>
-        <sonar-analyzer-commons.version>2.7.0.1482</sonar-analyzer-commons.version>
+        <sonar-analyzer-commons.version>2.8.0.2699</sonar-analyzer-commons.version>
         <sonar.orchestrator.version>4.0.0.404</sonar.orchestrator.version>
         <woodstox.version>6.2.7</woodstox.version>
 


### PR DESCRIPTION
1. Update sonar to support 10.4 & 10.4.1
2. Fix StaxParserTest 